### PR TITLE
Sb home

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -22,6 +22,24 @@
       "age": 2,
       "userId": 1,
       "id": 4
+    },
+    {
+      "name": "Morose",
+      "breed": "Whippet",
+      "neutered": "true",
+      "active": "true",
+      "age": 3,
+      "userId": 1,
+      "id": 5
+    },
+    {
+      "name": "Morris",
+      "breed": "Hound",
+      "neutered": "true",
+      "active": "false",
+      "age": 3,
+      "userId": 1,
+      "id": 6
     }
   ],
   "exercises": [

--- a/api/database.json
+++ b/api/database.json
@@ -13,6 +13,15 @@
       "userId": 1,
       "name": "Doodles",
       "breed": "Schoodle"
+    },
+    {
+      "name": "Captain",
+      "breed": "Shepherd",
+      "neutered": "true",
+      "active": "true",
+      "age": 2,
+      "userId": 1,
+      "id": 4
     }
   ],
   "exercises": [

--- a/src/components/home/DogCard.js
+++ b/src/components/home/DogCard.js
@@ -1,6 +1,5 @@
 import React, {Component} from "react"
-import PropTypes from "prop-types"
-import Home from "./Home"
+
 
 class DogCard extends Component {
 
@@ -21,16 +20,5 @@ class DogCard extends Component {
         )}}
 
 
-DogCard.propTypes = {
-    dogs: PropTypes.shape ({
-        id: PropTypes.number,
-        name: PropTypes.string,
-        breed: PropTypes.string,
-        active: PropTypes.bool,
-        neutered: PropTypes.bool,
-        age: PropTypes.number,
-        userId: PropTypes.number
-    })
-}
 
 export default DogCard;

--- a/src/components/home/DogCard.js
+++ b/src/components/home/DogCard.js
@@ -14,7 +14,7 @@ class DogCard extends Component {
                 {this.props.dog.breed}
               </h5>
             </div>
-            <button onClick={()=> {this.props.history.push(`/edit`)}}>Edit</button><button onClick={() => this.props.deleteDog(this.props.dog.id)}>Delete</button>
+            <button onClick={()=> {this.props.history.push(`/${this.props.dog.id}/edit`)}}>Edit</button><button onClick={() => this.props.deleteDog(this.props.dog.id)}>Delete</button>
           </div>
           </div>
         )}}

--- a/src/components/home/DogEditForm.js
+++ b/src/components/home/DogEditForm.js
@@ -1,0 +1,1 @@
+import React, {Component} from "react"

--- a/src/components/home/DogEditForm.js
+++ b/src/components/home/DogEditForm.js
@@ -1,1 +1,215 @@
-import React, {Component} from "react"
+import React, { Component } from "react";
+import { Form, Button, Row, Col } from "react-bootstrap";
+import DogManager from "../../modules/DogManager"
+import PropTypes from "prop-types"
+
+class DogEditForm extends Component {
+  state = {
+    name: "",
+    breed: "",
+    age: 1,
+    active: true,
+    neutered: true,
+    activeUser: 1
+  };
+
+  handleFieldChange = evt => {
+    const stateToChange = {};
+    stateToChange[evt.target.id] = evt.target.value;
+    this.setState(stateToChange);
+  };
+
+  //Handles age radio changes
+  handleOptionChange = evt => {
+    this.setState({
+      age: evt.target.value
+    });
+  };
+
+  //Handles Neuter/Intact radio changes
+  handleNeuterChange = evt => {
+    this.setState({
+      neuter: evt.target.value
+    });
+  };
+
+  //Handles activity level radio changes
+
+  handleActiveChange = evt => {
+    this.setState({
+      active: evt.target.value
+    });
+  };
+
+  componentDidMount(){
+    DogManager.getSingleDog(this.props.match.params.dogId)
+    .then(dog =>
+        this.setState({
+            userId: dog.userId,
+            name: dog.name,
+            breed: dog.breed,
+            active: dog.active,
+            neutered: dog.neutered,
+            age: dog.age
+        }))
+  }
+
+  updateDog = evt => {
+      const updatedDog = {
+          id: this.props.match.params.dogId,
+          userId: this.state.activeUser,
+          name: this.state.name,
+          breed: this.state.breed,
+          age: this.state.age,
+          active: this.state.active,
+          neutered: this.state.neutered
+
+      }
+      this.props.editDog(updatedDog)
+      this.props.history.push("/")
+
+  }
+
+
+  render() {
+    return (
+      <Form>
+        <Form.Group as={Row}>
+          <Form.Label column sm={2}>
+            Dog Name
+          </Form.Label>
+          <Col sm={10}>
+            <Form.Control
+              type="text"
+              placeholder="Dog Name"
+              onChange={this.handleFieldChange}
+              id="name"
+              value={this.state.name}
+            />
+          </Col>
+        </Form.Group>
+
+        <Form.Group as={Row}>
+          <Form.Label column sm={2}>
+            Breed
+          </Form.Label>
+          <Col sm={10}>
+            <Form.Control
+              type="text"
+              placeholder="Dog Breed"
+              onChange={this.handleFieldChange}
+              id="breed"
+              value={this.state.breed}
+            />
+          </Col>
+        </Form.Group>
+        {/* Age radio button */}
+        <fieldset>
+          <Form.Group as={Row}>
+            <Form.Label as="legend" column sm={2}>
+              Age
+            </Form.Label>
+            <Row sm={10}>
+              <Form.Check
+                type="radio"
+                label="0-4 Months"
+                name="age"
+                id="age"
+                value={1}
+                onChange={this.handleOptionChange}
+              />
+              <Form.Check
+                type="radio"
+                label="4 Months - Adult"
+                name="age"
+                id="age"
+                value={2}
+                onChange={this.handleOptionChange}
+              />
+              <Form.Check
+                type="radio"
+                label="Adult"
+                name="age"
+                id="age"
+                value={3}
+                onChange={this.handleOptionChange}
+              />
+            </Row>
+          </Form.Group>
+        </fieldset>
+        {/* Neutered/Intact radio buttons */}
+        <fieldset>
+          <Form.Group as={Row} controlId="formHorizontalCheck">
+            <Form.Label as="legend" column sm={2}>
+              Neutered/Spay
+            </Form.Label>
+            <Form.Check
+              type="radio"
+              label="Neutered/Spayed"
+              name="neutered"
+              id="neutered"
+              value={true}
+              onChange={this.handleNeuterChange}
+            />
+            <Form.Check
+              type="radio"
+              label="Intact"
+              name="neutered"
+              id="neutered"
+              value={false}
+              onChange={this.handleNeuterChange}
+            />
+          </Form.Group>
+        </fieldset>
+        {/* Activity level radio buttons */}
+        <fieldset>
+          <Form.Group as={Row} controlId="formHorizontalCheck">
+            <Form.Label as="legend" column sm={2}>
+              Active/Inactive
+            </Form.Label>
+            <Form.Check
+              type="radio"
+              label="Active"
+              name="active"
+              id="active"
+              value={true}
+              onChange={this.handleActiveChange}
+            />
+            <Form.Check
+              type="radio"
+              label="Inactive"
+              name="active"
+              id="active"
+              value={false}
+              onChange={this.handleActiveChange}
+            />
+          </Form.Group>
+        </fieldset>
+
+        <Form.Group as={Row}>
+          <Col sm={{ span: 10, offset: 2 }}>
+            <Button type="submit" onClick={this.addNewDog}>
+              Add Dog
+            </Button>
+          </Col>
+        </Form.Group>
+      </Form>
+    );
+  }
+}
+
+DogEditForm.propTypes = {
+    dog : PropTypes.shape ({
+        id: PropTypes.number,
+        userId: PropTypes.number,
+        name: PropTypes.string,
+        breed: PropTypes.string,
+        age: PropTypes.number,
+        active: PropTypes.bool,
+        neutered: PropTypes.bool,
+    })
+}
+
+
+
+export default DogEditForm;

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -8,13 +8,12 @@ class Home extends Component {
       <div>
           <div>
           {this.props.dogs.map((dog) => {
-              console.log(this.dog)
               return (
                   <DogCard dog={dog} key={dog.id} deleteDog={this.props.deleteDog} {...this.props}/>
               )
           })}
           </div>
-          <button></button>
+          <button onClick={() => this.props.history.push("/dogs/new")}>Add Another Dog</button><button>My Foods</button><button>My exercises</button>
       </div>
     );
   }

--- a/src/components/home/NewDogForm.js
+++ b/src/components/home/NewDogForm.js
@@ -1,0 +1,175 @@
+import React, {Component} from "react"
+import {Form, Col, Button, Row} from "react-bootstrap"
+
+class NewDogForm extends Component {
+    state={
+        name: "",
+        breed: "",
+        neutered: true,
+        active: false,
+        age: 1,
+        userId: 1
+        // parseInt(sessionStorage.getItem("activeUser"))
+    }
+
+    //Handles text input changes
+    handleFieldChange = evt => {
+        const stateToChange = {}
+        stateToChange[evt.target.id] = evt.target.value
+        this.setState(stateToChange)
+    }
+
+    //Handles Age radio changes
+    handleOptionChange = evt => {
+        this.setState({
+            age: evt.target.value
+        })
+    }
+
+    //Handles Neuter/Intact radio changes
+    handleNeuterChange = evt => {
+        this.setState({
+            neutered: evt.target.value
+        })
+    }
+
+    //Handles activity level radio changes
+    handleActiveChange = evt => {
+        this.setState({
+            active: evt.target.value
+        })
+    }
+
+    //Creates dog object from state and posts to database
+    addNewDog = evt => {
+        evt.preventDefault()
+        const dog = {
+            name: this.state.name,
+            breed: this.state.breed,
+            neutered: this.state.neutered,
+            active: this.state.active,
+            age: parseInt(this.state.age),
+            userId: this.state.userId
+        }
+        this.props.addNewDog(dog)
+        .then(this.props.history.push("/"))
+    }
+
+    render() {
+        return(
+            <Form>
+  <Form.Group as={Row} >
+    <Form.Label column sm={2}>
+      Dog Name
+    </Form.Label>
+    <Col sm={10}>
+      <Form.Control type="text" placeholder="Dog Name" onChange={this.handleFieldChange} id="name"/>
+    </Col>
+  </Form.Group>
+
+  <Form.Group as={Row} >
+    <Form.Label column sm={2}>
+      Breed
+    </Form.Label>
+    <Col sm={10}>
+      <Form.Control type="text" placeholder="Dog Breed" onChange={this.handleFieldChange} id="breed" />
+    </Col>
+  </Form.Group>
+  {/* Age radio button */}
+  <fieldset>
+    <Form.Group as={Row}>
+      <Form.Label as="legend" column sm={2}>
+        Age
+      </Form.Label>
+      <Row sm={10}>
+        <Form.Check
+          type="radio"
+          label="0-4 Months"
+          name="age"
+          id="age"
+          value={1}
+          onChange={this.handleOptionChange}
+        />
+        <Form.Check
+          type="radio"
+          label="4 Months - Adult"
+          name="age"
+          id="age"
+          value={2}
+          onChange={this.handleOptionChange}
+        />
+        <Form.Check
+          type="radio"
+          label="Adult"
+          name="age"
+          id="age"
+          value={3}
+          onChange={this.handleOptionChange}
+        />
+      </Row>
+    </Form.Group>
+  </fieldset>
+  {/* Neutered/Intact radio buttons */}
+  <fieldset>
+  <Form.Group as={Row} controlId="formHorizontalCheck">
+  <Form.Label as="legend" column sm={2}>
+        Neutered/Spay
+      </Form.Label>
+  <Form.Check
+          type="radio"
+          label="Neutered/Spayed"
+          name="neutered"
+          id="neutered"
+          value={true}
+          onChange={this.handleNeuterChange}
+        />
+        <Form.Check
+          type="radio"
+          label="Intact"
+          name="neutered"
+          id="neutered"
+          value={false}
+          onChange={this.handleNeuterChange}
+        />
+  </Form.Group>
+  </fieldset>
+  {/* Activity level radio buttons */}
+  <fieldset>
+  <Form.Group as={Row} controlId="formHorizontalCheck">
+  <Form.Label as="legend" column sm={2}>
+        Active/Inactive
+      </Form.Label>
+  <Form.Check
+          type="radio"
+          label="Active"
+          name="active"
+          id="active"
+          value={true}
+          onChange={this.handleActiveChange}
+        />
+        <Form.Check
+          type="radio"
+          label="Inactive"
+          name="active"
+          id="active"
+          value={false}
+          onChange={this.handleActiveChange}
+        />
+  </Form.Group>
+  </fieldset>
+
+  <Form.Group as={Row}>
+    <Col sm={{ span: 10, offset: 2 }}>
+      <Button type="submit" onClick={this.addNewDog}>Add Dog</Button>
+    </Col>
+  </Form.Group>
+</Form>
+
+        )
+
+
+    }
+
+}
+
+export default NewDogForm;

--- a/src/modules/DogManager.js
+++ b/src/modules/DogManager.js
@@ -20,7 +20,7 @@ const DogManager = {
                 "Content-Type": "application/json"
             },
             body: JSON.stringify(dogObject)
-        }).then(r => r.json)
+        }).then(r => r.json())
     },
 
     editDog: (dogObject) => {


### PR DESCRIPTION
Home page should display cards with user's dogs (name, and breed) along with edit and delete buttons. At the bottom of page should be three buttons - "Add another dog", "My foods", and "My exercises". 

The "Add another dog" button takes the user to a form where they may enter their dog's name and breed into text input fields, and the dog's age, activity level, and neuter/spay status in radio button inputs. Clicking "Add dog" will then add the dog to the database, redirect to the home page with the user's list of dogs, and update the list to include a card with the new dog's information.

The "Delete" button on the dog card will delete the dog from database and update the user's dog list by removing that car.

The "Edit" button on the dog card will take the user to an edit form with the "name" and "breed" text inputs pre-filled with the dog's information. Radio buttons do not pre-populate as of yet.

The "Add dog" button on the edit form does not currently activate.

